### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/pkg/controllers/apps/distributed.go
+++ b/pkg/controllers/apps/distributed.go
@@ -796,7 +796,8 @@ func (r *SidekickReconciler) deleteMW(ctx context.Context, mw *apiworkv1.Manifes
 }
 
 func (r *SidekickReconciler) setMWDeletionInitiatorAnnotation(ctx context.Context, mw *apiworkv1.ManifestWork) error {
-	_, err := cu.CreateOrPatch(ctx, r.Client, mw,
+	_, err := cu.CreateOrPatch(
+		ctx, r.Client, mw,
 		func(in client.Object, createOp bool) client.Object {
 			po := in.(*apiworkv1.ManifestWork)
 			if po.Annotations == nil {
@@ -905,7 +906,8 @@ func (r *SidekickReconciler) handleDistributedSidekickFinalizer(ctx context.Cont
 		}
 	}
 
-	_, err := cu.CreateOrPatch(ctx, r.Client, sidekick,
+	_, err := cu.CreateOrPatch(
+		ctx, r.Client, sidekick,
 		func(in client.Object, createOp bool) client.Object {
 			sk := in.(*appsv1alpha1.Sidekick)
 			sk.ObjectMeta = core_util.AddFinalizer(sk.ObjectMeta, getFinalizerName())
@@ -932,7 +934,8 @@ func (r *SidekickReconciler) terminateManifestWork(ctx context.Context, sidekick
 		}
 	}
 
-	_, err = cu.CreateOrPatch(context.TODO(), r.Client, sidekick,
+	_, err = cu.CreateOrPatch(
+		context.TODO(), r.Client, sidekick,
 		func(in client.Object, createOp bool) client.Object {
 			sk := in.(*appsv1alpha1.Sidekick)
 			sk.ObjectMeta = core_util.RemoveFinalizer(sk.ObjectMeta, getFinalizerName())

--- a/pkg/controllers/apps/pod.go
+++ b/pkg/controllers/apps/pod.go
@@ -82,7 +82,8 @@ func (r *SidekickReconciler) removePodFinalizerIfMarkedForDeletion(ctx context.C
 }
 
 func (r *SidekickReconciler) removePodFinalizer(ctx context.Context, pod *corev1.Pod) error {
-	_, err := cu.CreateOrPatch(ctx, r.Client, pod,
+	_, err := cu.CreateOrPatch(
+		ctx, r.Client, pod,
 		func(in client.Object, createOp bool) client.Object {
 			pod := in.(*corev1.Pod)
 			pod.ObjectMeta = core_util.RemoveFinalizer(pod.ObjectMeta, getFinalizerName())
@@ -101,7 +102,8 @@ func (r *SidekickReconciler) deletePod(ctx context.Context, pod *corev1.Pod) err
 }
 
 func (r *SidekickReconciler) setDeletionInitiatorAnnotation(ctx context.Context, pod *corev1.Pod) error {
-	_, err := cu.CreateOrPatch(ctx, r.Client, pod,
+	_, err := cu.CreateOrPatch(
+		ctx, r.Client, pod,
 		func(in client.Object, createOp bool) client.Object {
 			pod := in.(*corev1.Pod)
 			if pod.Annotations == nil {

--- a/pkg/controllers/apps/sidekick.go
+++ b/pkg/controllers/apps/sidekick.go
@@ -37,7 +37,8 @@ func (r *SidekickReconciler) handleSidekickFinalizer(ctx context.Context, sideki
 		}
 	}
 
-	_, err := cu.CreateOrPatch(ctx, r.Client, sidekick,
+	_, err := cu.CreateOrPatch(
+		ctx, r.Client, sidekick,
 		func(in client.Object, createOp bool) client.Object {
 			sk := in.(*appsv1alpha1.Sidekick)
 			sk.ObjectMeta = core_util.AddFinalizer(sk.ObjectMeta, getFinalizerName())

--- a/pkg/controllers/apps/sidekick_controller.go
+++ b/pkg/controllers/apps/sidekick_controller.go
@@ -189,7 +189,8 @@ func (r *SidekickReconciler) createSidekickPod(ctx context.Context, sidekick *ap
 	// kubectl delete, then pod will be gracefully terminated which will led
 	// to pod.status.phase: succeeded. We need to control this behaviour.
 	// By adding finalizer, we will know who is deleting the object
-	_, err = cu.CreateOrPatch(ctx, r.Client, pod,
+	_, err = cu.CreateOrPatch(
+		ctx, r.Client, pod,
 		func(in client.Object, createOp bool) client.Object {
 			p := in.(*corev1.Pod)
 			p.ObjectMeta = core_util.AddFinalizer(p.ObjectMeta, getFinalizerName())
@@ -330,7 +331,8 @@ func (r *SidekickReconciler) terminate(ctx context.Context, sidekick *appsv1alph
 		return err
 	}
 
-	_, err = cu.CreateOrPatch(ctx, r.Client, sidekick,
+	_, err = cu.CreateOrPatch(
+		ctx, r.Client, sidekick,
 		func(in client.Object, createOp bool) client.Object {
 			sk := in.(*appsv1alpha1.Sidekick)
 			sk.ObjectMeta = core_util.RemoveFinalizer(sk.ObjectMeta, getFinalizerName())

--- a/pkg/snapshotserver/snapshot.go
+++ b/pkg/snapshotserver/snapshot.go
@@ -98,7 +98,8 @@ func (r *CommandServer) updateSnapshotStatus(ctx context.Context, snapshot *stor
 			in.Status.TotalComponents = snapshot.Status.TotalComponents
 			in.Status.Components = snapshot.Status.Components
 			return in
-		})
+		},
+	)
 	return err
 }
 


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
